### PR TITLE
Fix syncthing startup failure by setting HOME

### DIFF
--- a/syncthing.service
+++ b/syncthing.service
@@ -2,8 +2,9 @@
 Description=syncthing
 
 [Service]
-ExecStart=/opt/bin/syncthing -no-browser -no-restart
-Restart=always
+Environment="HOME=/home/root"
+ExecStart=/opt/bin/syncthing serve --no-browser --no-restart
+Restart=unless-stopped
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Otherwise starting syncthing fails for me with:

```
Jan 17 08:29:34 reMarkable systemd[1]: Started syncthing.
Jan 17 08:29:34 reMarkable syncthing[5133]: $HOME is not defined
Jan 17 08:29:34 reMarkable syncthing[5133]: panic: Failed to get user home dir
Jan 17 08:29:34 reMarkable syncthing[5133]: goroutine 1 [running]:
Jan 17 08:29:34 reMarkable syncthing[5133]: github.com/syncthing/syncthing/lib/locations.userHomeDir()
Jan 17 08:29:34 reMarkable syncthing[5133]:         /media/ware3/Entware.2022.12/build_dir/target-arm_cortex-a9_glibc-2.27_eabi/syncthing-hf/syncthing-1.22.1/src/github.com/syncthing/syncthing/lib/locations/locations.go:228 +0xb0
Jan 17 08:29:34 reMarkable syncthing[5133]: github.com/syncthing/syncthing/lib/locations.init.0()
Jan 17 08:29:34 reMarkable syncthing[5133]:         /media/ware3/Entware.2022.12/build_dir/target-arm_cortex-a9_glibc-2.27_eabi/syncthing-hf/syncthing-1.22.1/src/github.com/syncthing/syncthing/lib/locations/locations.go:56 +0x14
```